### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+* @kumavale

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,5 +9,3 @@ updates:
       dependencies:
         patterns:
           - "*"
-    reviewers:
-      - "kumavale"


### PR DESCRIPTION
## About

> The `reviewers` field in the `dependabot.yml` file will be removed soon. Please use the code owners file to specify reviewers for Dependabot PRs. For more information, see [this blog post](https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/).
> 
> _Originally posted by @dependabot[bot] in https://github.com/kumavale/sisterm/issues/32#issuecomment-2929678729_
            